### PR TITLE
Use forever to restart flood after crashing

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -40,6 +40,7 @@ source /root/aur.sh
 
 # install flood
 cd /etc/webapps/flood && npm install --production
+npm i -g forever 
 
 # download autodl-irssi community plugin
 /root/github.sh -df "github-download.zip" -dp "/tmp" -ep "/tmp/extracted" -ip "/usr/share/webapps/rutorrent/plugins/autodl-irssi" -go "autodl-community" -gr "autodl-rutorrent" -rt "source"

--- a/run/nobody/flood.sh
+++ b/run/nobody/flood.sh
@@ -31,8 +31,9 @@ if [[ "${ENABLE_FLOOD}" == "yes" || "${ENABLE_FLOOD}" == "both" ]]; then
 	echo "[info] Starting Flood..."
 
 	# run tmux attached to flood (non daemonized, blocking)
-	cd "${flood_install_path}" && /usr/bin/script /home/nobody/typescript --command "/usr/bin/tmux new-session -s flood -n flood npm run start:production" &>/dev/null
-
+	# cd "${flood_install_path}" && /usr/bin/script /home/nobody/typescript --command "/usr/bin/tmux new-session -s flood -n flood npm run start:production" &>/dev/null
+	# run flood with forever
+	cd "${flood_install_path}" && "forever start -c 'npm start' ."
 else
 
 	echo "[info] Flood not enabled, skipping starting Flood Web UI"

--- a/run/nobody/flood.sh
+++ b/run/nobody/flood.sh
@@ -33,7 +33,7 @@ if [[ "${ENABLE_FLOOD}" == "yes" || "${ENABLE_FLOOD}" == "both" ]]; then
 	# run tmux attached to flood (non daemonized, blocking)
 	# cd "${flood_install_path}" && /usr/bin/script /home/nobody/typescript --command "/usr/bin/tmux new-session -s flood -n flood npm run start:production" &>/dev/null
 	# run flood with forever
-	cd "${flood_install_path}" && "forever start -c 'npm start' ."
+	cd "${flood_install_path}" && /usr/bin/script /home/nobody/typescript --command "forever start -c 'npm start' ."
 else
 
 	echo "[info] Flood not enabled, skipping starting Flood Web UI"


### PR DESCRIPTION
I have been having some issues with flood crashing on my installation, to fix this I added the node.js forever module to restart flood after any crashes. 

If there is any interest in merging this in, please let me know and I'll make any stylistic or other changes you request. 

Thanks.
