### PR TITLE
Add option to aut-extract torrents on download

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -56,6 +56,7 @@ cd /etc/webapps/flood && npm install --production
 
 # download unrarall to be able to auto extract downloaded files
 /root/curly.sh -rc 6 -rw 10 -of /home/nobody/unrarall.sh -url "https://raw.githubusercontent.com/arfoll/unrarall/master/unrarall"
+chmod +x /home/nobody/unrarall.sh
 
 # extract compiled version of htpasswd
 tar -xvf /tmp/htpasswd.tar.gz -C /

--- a/config/nobody/rtorrent/config/rtorrent.rc
+++ b/config/nobody/rtorrent/config/rtorrent.rc
@@ -3,10 +3,10 @@
 # uncomment the options you wish to enable.
 
 # gets the full path of data of a torrent (it's a workaround for the possibly empty 'd.base_path' attribute)
-method.insert = d.data_path, simple, "if=(d.is_multi_file), (cat,(d.directory),/), (cat,(d.directory),/,(d.$
+method.insert = d.data_path, simple, "if=(d.is_multi_file), (cat,(d.directory),/), (cat,(d.directory),/,(d.name))"
 
 # Extract when finsihed
-# method.set_key=event.download.finished,filebot,"execute.throw.bg={/home/nobody/unrarall.sh,$d.base_path=,$d.n$
+method.set_key=event.download.finished,filebot,"execute.throw.bg={/data/media/rtunrar.sh,$d.base_path=,$d.name=}"
 
 # Maximum number of simultaneous downloads and uploads slots (global slots!) (`max_downloads_global`, `max_uploads_global`)
 #

--- a/config/nobody/rtorrent/config/rtorrent.rc
+++ b/config/nobody/rtorrent/config/rtorrent.rc
@@ -6,7 +6,7 @@
 method.insert = d.data_path, simple, "if=(d.is_multi_file), (cat,(d.directory),/), (cat,(d.directory),/,(d.$
 
 # Extract when finsihed
-# method.set_key=event.download.finished,filebot,"execute.throw.bg={/hom/nobody/unrarall.sh,$d.base_path=,$d.n$
+# method.set_key=event.download.finished,filebot,"execute.throw.bg={/home/nobody/unrarall.sh,$d.base_path=,$d.n$
 
 # Maximum number of simultaneous downloads and uploads slots (global slots!) (`max_downloads_global`, `max_uploads_global`)
 #


### PR DESCRIPTION
Using [unrarall](https://github.com/arfoll/unrarall), this PR makes it optional to auto-extract downloaded torrents.

Since the unrarall file already is so well documented it's not needed to document how to use it, it's already in there.

Personally I put the script in my `/data/downloads` folder so that it's reachable from both the HOST and Docker itself.

Please SQUASH and merge, the commit history is kind of ugly. :)